### PR TITLE
Update Typo in TMC2209_HW_Abstraction.h

### DIFF
--- a/tmc/ic/TMC2209/TMC2209_HW_Abstraction.h
+++ b/tmc/ic/TMC2209/TMC2209_HW_Abstraction.h
@@ -46,7 +46,7 @@
 #define TMC2209_CHOPCONF      0x6C
 #define TMC2209_DRV_STATUS    0x6F
 #define TMC2209_PWMCONF       0x70
-#define TMC2209_PWMSCALE      0x71
+#define TMC2209_PWM_SCALE     0x71
 #define TMC2209_PWM_AUTO      0x72
 
 // Register fields in TMC2209


### PR DESCRIPTION
The definition for #PWMSCALE is presumably missing the underscore (line 49).

This definition is intended to be used in lines 296 and 299 with the underscore PWM_SCALE. This would also be consistent naming convention as PWM_AUTO.

I do not currently use any other TMC ICs, but if this change is approved then this typo could be present in other ICs. 