### PR TITLE
Set correct address for tmc2160 initial read

### DIFF
--- a/tmc/ic/TMC2160/TMC2160.c
+++ b/tmc/ic/TMC2160/TMC2160.c
@@ -157,6 +157,8 @@ int32_t readRegisterSPI(uint16_t icID, uint8_t address)
     if (tmc2160_cache(icID, TMC2160_CACHE_READ, address, &value))
         return value;
 
+    // clear write bit
+    data[0] = address & TMC2160_ADDRESS_MASK;
 
     // Send the read request
     tmc2160_readWriteSPI(icID, &data[0], sizeof(data));


### PR DESCRIPTION
The TMC2160 driver is missing a line of code that correctly sets the SPI datagram address. Without this line, the initial bytes sent during a SPI read are all 0s. The correct implementation is that the first byte is a 7-bit address with the RW bit cleared.
